### PR TITLE
HeaderComponent Breadcrumbs Margin

### DIFF
--- a/src/components/layout/HeaderComponent.vue
+++ b/src/components/layout/HeaderComponent.vue
@@ -1103,6 +1103,6 @@ header {
 }
 
 @include break-mobile-sm {
-  #header-spacer { margin-bottom: 1.5rem; }
+  #header-spacer { margin-bottom: 3.5rem; }
 }
 </style>


### PR DESCRIPTION
Adding more margin-bottom to the header component on mobile to account for breadcrumbs

NOTE: Merge into proxy after this PR is merged