### PR TITLE
Css layout update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,6 +112,7 @@ main {
       "main main"
       "sidebar sidebar";
     grid-gap: 2rem;
+    column-gap: 0;
     row-gap: 0;
     margin-bottom: 2rem;
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -106,7 +106,6 @@ main {
   #public-content {
     @include base-layout-width;
     @include grid-base-layout;
-    @include grid-columns-base;
     // margin-top: $header-bottom-margin;
     grid-template-areas:
       "header header"

--- a/src/assets/scss/_global-components.scss
+++ b/src/assets/scss/_global-components.scss
@@ -979,7 +979,6 @@ input[disabled].toggle-switch:checked + label:after { background-color: lighten(
   color: $sub-header-font-color;
   margin: 1.5rem 0;
   max-height: calc(100vh - 16rem);
-  min-height: 200px;
   overflow-x: hidden;
   overflow-y: auto;
   button { margin: 0.5rem 0 0; width: 100%; }

--- a/src/components/polls/PollViewer.vue
+++ b/src/components/polls/PollViewer.vue
@@ -1,12 +1,20 @@
 <template>
   <div class="polls" id="poll-view" v-if="poll">
     <!-- Poll Header -->
-    <div class="poll-title">
+    <div class="poll-title collapse-section" @click="togglePollsCollapsed()">
       <span class="poll-title-text">
+        <a :class="{ 'is-open': !options.polls_collapsed, 'is-closed': options.polls_collapsed }">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.84 22.63" class="icon__caretDown">
+            <title></title>
+            <g id="Layer_2" data-name="Layer 2">
+              <polyline class="icon" points="37.92 1.92 19.92 19.92 1.92 1.92" />
+            </g>
+          </svg>
+        </a>
         Poll
         <span class="is_locked" v-if="pollCopy.locked">(Locked)</span>
       </span>
-      <div class="poll-controls">
+      <div v-if="!options.polls_collapsed" class="poll-controls">
         <!-- Poll Controls -->
         <div class="poll-control" v-if="canLock()">
           <input id="lockPoll" class="icon" type="checkbox" v-model="pollCopy.locked">
@@ -32,7 +40,7 @@
     </div>
 
     <!-- Poll Edit -->
-    <div class="poll-edit" v-if="canEdit()" :class="{'showing': editPoll, 'hidden': !editPoll}">
+    <div class="poll-edit" v-if="canEdit() && !options.polls_collapsed" :class="{'showing': editPoll, 'hidden': !editPoll}">
       <div class="slide-wrapper">
         <div class="poll-edit-container">
           <h5 class="panelTitle">Edit Poll Options:</h5>
@@ -71,7 +79,7 @@
       </div>
     </div>
 
-    <div class="poll-body">
+    <div v-if="!options.polls_collapsed" class="poll-body">
       <div class="poll-header">
         <!-- Poll Details -->
         <div class="poll-header-main">
@@ -117,7 +125,7 @@
         </div>
       </div>
     </div>
-    <div class="actionsBar">
+    <div v-if="!options.polls_collapsed" class="actionsBar">
       <button @click="vote()" :disabled="pollAnswers.length === 0" v-if="canVote()">Vote</button>
       <button v-if="canRemoveVote()" @click="removeVote()" class="secondary">Remove Vote</button>
     </div>
@@ -288,6 +296,11 @@ export default {
       console.log('scrollPollView')
       // $('#poll-view').animate({  scrollTop: 0 }, 250)
     }
+
+    const togglePollsCollapsed = () => {
+      v.options.polls_collapsed = !v.options.polls_collapsed
+    }
+
     /* Internal Data */
     const $auth = inject(AuthStore)
     const $alertStore = inject('$alertStore')
@@ -303,7 +316,8 @@ export default {
         display_mode: props.poll.display_mode,
         // used in view to track date and time from input field
         expiration_date: props.poll.expiration ? dayjs(props.poll.expiration).format('YYYY-MM-DD') : undefined,
-        expiration_time: props.poll.expiration ? dayjs(props.poll.expiration).format('HH:mm') : undefined
+        expiration_time: props.poll.expiration ? dayjs(props.poll.expiration).format('HH:mm') : undefined,
+        polls_collapsed: false
       },
       editPoll: false,
       pollAnswers: [],
@@ -334,7 +348,8 @@ export default {
       updateLockPoll,
       calcExpiration,
       scrollPollView,
-      humanDate
+      humanDate,
+      togglePollsCollapsed
     }
   }
 }
@@ -349,6 +364,36 @@ export default {
   }
   &.hidden {
     max-height: 0rem;
+  }
+}
+
+.collapse-section {
+  @include no-select;
+  cursor: pointer;
+  a { margin-left: -0.5rem; }
+  .title { display: inline-block; margin-left: .5rem; }
+  .is-open {
+    .icon__caretDown {
+      transform: rotateZ(0deg);
+      transition: all ease-in-out 150ms;
+    }
+  }
+  .is-closed {
+    .icon__caretDown {
+      transform: rotateZ(-90deg);
+      transition: all ease-in-out 150ms;
+    }
+  }
+  .icon__caretDown {
+    margin-bottom: 3px;
+    width: 8px;
+    polyline {
+      fill: none;
+      stroke: $secondary-font-color;
+      stroke-linecap: round;
+      stroke-miterlimit: 10;
+      stroke-width: 7px;
+    }
   }
 }
 </style>

--- a/src/components/users/UserPosts.vue
+++ b/src/components/users/UserPosts.vue
@@ -253,6 +253,9 @@ export default {
     }
     &.closed {
       width: 100%;
+      @include break-mobile-sm {
+        max-height: 3rem;
+      }
       max-height: 2.5rem;
       white-space: pre-wrap;
       overflow: hidden;

--- a/src/views/Boards.vue
+++ b/src/views/Boards.vue
@@ -307,10 +307,9 @@ img.avatar-small {
       padding-top: 0.5rem;
       @include info-text;
       word-break: break-word;
+      flex: 0.5 1 120px;
       @include break-min-desktop {
         text-align: right;
-        flex: 0.5 1 150px;
-        // flex: 1 1;
       }
     }
 

--- a/src/views/Boards.vue
+++ b/src/views/Boards.vue
@@ -55,12 +55,12 @@
                 <!-- Board Posts and Threads -->
                 <div class="view-count">
                   <p class="view-count-posts">
-                    <span class="view-count-number">{{board.total_post_count}}</span>
-                     <span class="label"> posts, </span>
+                    <span class="view-count-number">{{board.total_post_count.toLocaleString()}}</span>
+                     <span class="label"> Posts </span>
                   </p>
                   <p class="view-count-threads">
-                    <span class="view-count-number">{{board.total_thread_count}}</span>
-                     <span class="label"> threads</span>
+                    <span class="view-count-number">{{board.total_thread_count.toLocaleString()}}</span>
+                     <span class="label"> Threads</span>
                   </p>
                 </div>
 

--- a/src/views/Boards.vue
+++ b/src/views/Boards.vue
@@ -51,34 +51,32 @@
                 </div>
               </div>
 
-              <div class="board-secondary">
-                <!-- Board Posts and Threads -->
-                <div class="view-count">
-                  <p class="view-count-posts">
-                    <span class="view-count-number">{{board.total_post_count.toLocaleString()}}</span>
-                     <span class="label"> Posts </span>
-                  </p>
-                  <p class="view-count-threads">
-                    <span class="view-count-number">{{board.total_thread_count.toLocaleString()}}</span>
-                     <span class="label"> Threads</span>
-                  </p>
-                </div>
+              <!-- Board Posts and Threads -->
+              <div class="view-count">
+                <p class="view-count-posts">
+                  <span class="view-count-number">{{board.total_post_count.toLocaleString()}}</span>
+                    <span class="label"> Posts </span>
+                </p>
+                <p class="view-count-threads">
+                  <span class="view-count-number">{{board.total_thread_count.toLocaleString()}}</span>
+                    <span class="label"> Threads</span>
+                </p>
+              </div>
 
-                <!-- Board Last Post By -->
-                <div class="last-post">
-                  <div v-if="board.last_post_username">
-                    <span v-if="board.user_deleted || board.post_deleted">deleted</span>
-                    <img v-if="!board.user_deleted && !board.post_deleted" class="avatar-small" :class="defaultAvatarShape" :src="board.last_post_avatar || defaultAvatar" @error="$event.target.src=defaultAvatar" />
-                    <router-link v-if="!board.user_deleted && !board.post_deleted" :to="{ path: '/profile/' + board.last_post_username.toLowerCase(), query: { id: board.last_post_user_id }}">{{board.last_post_username}}</router-link> posted in
-                    <span v-if="board.last_thread_title">
-                      <router-link :to="{ name: 'Posts', params: { threadSlug: board.last_thread_slug }, query: { start: board.last_post_position} }">
-                        <span v-html="board.last_thread_title"></span>
-                      </router-link> on
-                    </span>
-                    <span vi-if="board.last_post_created_at">
-                      <span>{{humanDate(board.last_post_created_at)}}</span>
-                    </span>
-                  </div>
+              <!-- Board Last Post By -->
+              <div class="last-post">
+                <div v-if="board.last_post_username">
+                  <span v-if="board.user_deleted || board.post_deleted">deleted</span>
+                  <img v-if="!board.user_deleted && !board.post_deleted" class="avatar-small" :class="defaultAvatarShape" :src="board.last_post_avatar || defaultAvatar" @error="$event.target.src=defaultAvatar" />
+                  <router-link v-if="!board.user_deleted && !board.post_deleted" :to="{ path: '/profile/' + board.last_post_username.toLowerCase(), query: { id: board.last_post_user_id }}">{{board.last_post_username}}</router-link> posted in
+                  <span v-if="board.last_thread_title">
+                    <router-link :to="{ name: 'Posts', params: { threadSlug: board.last_thread_slug }, query: { start: board.last_post_position} }">
+                      <span v-html="truncate(decode(board.last_thread_title), 25)"></span>
+                    </router-link>
+                  </span>
+                  <span vi-if="board.last_post_created_at">
+                    <br />on <span>{{humanDate(board.last_post_created_at)}}</span>
+                  </span>
                 </div>
               </div>
             </div>
@@ -96,6 +94,8 @@
 import useSWRV from 'swrv'
 import { mutate } from 'swrv'
 import humanDate from '@/composables/filters/humanDate'
+import decode from '@/composables/filters/decode'
+import truncate from '@/composables/filters/truncate'
 import RecentThreads from '@/components/threads/RecentThreads.vue'
 import LoginModal from '@/components/modals/auth/Login.vue'
 import RegisterModal from '@/components/modals/auth/Register.vue'
@@ -160,7 +160,7 @@ export default {
     watch(() => v.loggedIn, () => v.boardData.mutate(getBoards)) // Update boards on login
     watch(() => v.boardData.error, err => err ? $alertStore.error(err) : null) // Handle errors
 
-    return { ...toRefs(v), generateCatId, toggleCategory, humanDate }
+    return { ...toRefs(v), generateCatId, toggleCategory, humanDate, decode, truncate }
   }
 }
 </script>
@@ -236,7 +236,8 @@ img.avatar-small {
   .board {
     display: flex;
     flex-direction: row;
-    padding: 0 0 1rem 0;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(215, 215, 215, 0.35);
     @include break-mobile-sm { flex-direction: column; }
     .info {
       flex: 2 0 0;
@@ -277,15 +278,11 @@ img.avatar-small {
       }
     }
 
-    .board-secondary {
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-    }
-
     .view-count {
+      padding-top: 0.5rem;
+      flex: 0 1 10%;
+      margin-right: 1rem;
       @include info-text;
-      flex: 0 0 50%;
 
       &-posts,
       &-threads {
@@ -307,15 +304,17 @@ img.avatar-small {
     }
 
     .last-post {
+      padding-top: 0.5rem;
       @include info-text;
-      flex: 2;
       word-break: break-word;
+      @include break-min-desktop {
+        text-align: right;
+        flex: 0.5 1 150px;
+        // flex: 1 1;
+      }
     }
 
-    @include break-max-desktop {
-      .view-count {
-        flex: 0 0 auto;
-      }
+    @include break-mobile-sm {
       .view-count-posts,
       .view-count-threads {
         display: inline;
@@ -325,18 +324,6 @@ img.avatar-small {
         text-align: left;
       }
     }
-
-    @include break-min-desktop {
-      .info {
-        flex: 2;
-      }
-      .board-secondary {
-        flex-direction: row;
-          .view-count {
-            padding-right: 2rem;
-          }
-        }
-      }
   }
 
   @include break-mobile-sm {

--- a/src/views/Posts.vue
+++ b/src/views/Posts.vue
@@ -99,6 +99,9 @@
     </div>
 
     <!-- <pagination page-count="PostsParentCtrl.pageCount" page="PostsParentCtrl.page"></pagination> -->
+     
+    <!-- Poll Viewer -->
+    <poll-viewer v-if="postData.data.thread?.poll" :poll="postData.data.thread.poll" :thread="postData.data.thread" :user-priority="postData.data.posts[0].user.priority" :reset="resetPoll" :banned-from-board="bannedFromBoard"></poll-viewer>
 
   </div>
 
@@ -399,9 +402,6 @@
 
         </div>
       </div>
-
-      <!-- Poll Viewer -->
-      <poll-viewer v-if="postData.data.thread?.poll" :poll="postData.data.thread.poll" :thread="postData.data.thread" :user-priority="postData.data.posts[0].user.priority" :reset="resetPoll" :banned-from-board="bannedFromBoard"></poll-viewer>
     </div>
 
   </div>

--- a/src/views/Posts.vue
+++ b/src/views/Posts.vue
@@ -489,6 +489,7 @@ export default {
         return postsApi.byThread(params)
         .then(data => next(vm => {
           vm.postData.data = data
+          document.title = `${vm.postData.data.thread.title.replaceAll(/&#\d+;/g, '').trim()} - Posts`
           vm.checkUsersOnline()
           BanStore.updateBanNotice(vm.postData.data.banned_from_board)
           vm.bannedFromBoard = vm.postData.data.banned_from_board
@@ -509,6 +510,7 @@ export default {
         threadsApi.viewed(threadId)
         return postsApi.byThread(params).then(data => {
           this.postData.data = data
+          document.title = `${this.postData.data.thread.title.replaceAll(/&#\d+;/g, '').trim()} - Posts`
           this.checkUsersOnline()
           BanStore.updateBanNotice(this.postData.data.banned_from_board)
           this.bannedFromBoard = this.postData.data.banned_from_board

--- a/src/views/Posts.vue
+++ b/src/views/Posts.vue
@@ -1229,7 +1229,6 @@ $postWidth__mobile: calc(100vw - 2rem);
 }
 #public-content {
   .posts & {
-    grid-template-columns: minmax(0, 3fr) minmax($sidebarWidth, 1fr);
     grid-template-areas:
       "top sidebar"
       "ads sidebar"

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -373,7 +373,6 @@ export default {
 .profile-wrap {
   grid-column: span 2;
   display: grid;
-  @include grid-columns-base;
   grid-template-areas:
     "header sidebar"
     "main sidebar";

--- a/src/views/Profile.vue
+++ b/src/views/Profile.vue
@@ -206,6 +206,7 @@ export default {
   beforeRouteEnter(to, from, next) {
     usersApi.find(to.query.id).then(u => next(vm => {
       vm.user = u
+      document.title = `${vm.user.username} - Profile`
       isOnline(u.id, (e, d) => vm.userOnline = d.online)
     }))
   },

--- a/src/views/Threads.vue
+++ b/src/views/Threads.vue
@@ -279,6 +279,7 @@ export default {
       return threadsApi.byBoard(params)
       .then(d => next(vm => {
         vm.threadData.data = processThreads(d)
+        document.title = `${vm.threadData.data.board.name} - Threads`
         vm.banned = BanStore.updateBanNotice(vm.threadData.data.banned_from_board)
       }))
     })
@@ -295,6 +296,7 @@ export default {
       params.board_id = boardId
       return threadsApi.byBoard(params).then(d => {
         this.threadData.data = processThreads(d)
+        document.title = `${this.threadData.data.board.name} - Threads`
         this.banned = BanStore.updateBanNotice(this.threadData.data.banned_from_board)
         next()
       })

--- a/src/views/Threads.vue
+++ b/src/views/Threads.vue
@@ -31,10 +31,10 @@
             </div>
           </td>
           <td class="views">
-              <span class="views-number">{{childBoard.total_post_count}}</span>
-              <span class="label"> posts, </span>
-              <span class="views-number">{{childBoard.total_thread_count}}</span>
-              <span class="label"> threads</span>
+            <span class="views-number">{{childBoard.total_post_count.toLocaleString()}}</span>
+            <span class="label"> Posts</span>
+            <span class="views-number">{{childBoard.total_thread_count.toLocaleString()}}</span>
+            <span class="label"> Threads</span>
           </td>
 
           <td class="last-post">
@@ -48,10 +48,10 @@
               </router-link>
               <span v-if="childBoard.last_thread_id">
                 posted in
-                <router-link :title="decode(childBoard.last_thread_title)" :to="{ name: 'Posts', params: { threadSlug: childBoard.last_thread_slug }, query: { start: childBoard.last_post_position } }"><span v-html="truncate(decode(childBoard.last_thread_title), 25)"></span></router-link> on
+                <router-link :title="decode(childBoard.last_thread_title)" :to="{ name: 'Posts', params: { threadSlug: childBoard.last_thread_slug }, query: { start: childBoard.last_post_position } }"><span v-html="truncate(decode(childBoard.last_thread_title), 25)"></span></router-link>
               </span>
               <span v-if="childBoard.last_thread_id">
-                {{humanDate(childBoard.last_post_created_at)}}
+                <br />on {{humanDate(childBoard.last_post_created_at)}}
               </span>
             </div>
           </td>
@@ -197,8 +197,9 @@
           </td>
 
           <td class="views-replies" v-if="thread.user.username">
-            <span class="replies">{{ thread.is_proxy ? thread.post_count : thread.post_count - 1 || 0 }}</span>
-            <span class="views">{{ thread.view_count || 0 }}</span>
+            <span class="replies">{{ thread.is_proxy ? thread.post_count.toLocaleString() : (thread.post_count - 1).toLocaleString() || 0 }}</span>
+            <span class="views">{{ thread.view_count.toLocaleString() || 0 }}</span>
+
           </td>
 
           <td class="last-post" v-if="thread.user.username">
@@ -727,6 +728,9 @@ export default {
   }
 
   .last-post {
+    @include break-min-desktop {
+      text-align: right;
+    }
     color: $secondary-font-color;
     font-size: $font-size-sm;
   }


### PR DESCRIPTION
- Updated layout of pages to use full width of container (1300px)
- Added thousands separators to large numbers
- Added updating the document title for each page
- Restructured board listing flex spacing
  - Added border-bottom to boards to differentiate between them (same as threads and posts)
- Added polls to the top of a thread
  - Added collapse to polls
- Added height to user posts on mobile to avoid from being cutoff


